### PR TITLE
Add IScope and IScopeManager for context propagation

### DIFF
--- a/src/OpenTracing/IScope.cs
+++ b/src/OpenTracing/IScope.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace OpenTracing
+{
+    /// <summary>
+    /// A <see cref="IScope"/> formalizes the activation and deactivation of a <see cref="ISpan"/>, usually from a CPU standpoint.
+    ///
+    /// Many times a <see cref="ISpan"/> will be extant (in that <see cref="ISpan.Finish()"/> has not been called) despite being in a
+    /// non-runnable state from a CPU/scheduler standpoint. For instance, a <see cref="ISpan"/> representing the client side of an
+    /// RPC will be unfinished but blocked on IO while the RPC is still outstanding. A <see cref="IScope"/> defines when a given
+    /// <see cref="ISpan"/> is scheduled and on the path.
+    /// <see cref="IScope.Dispose()"/> mark the end of the active period for the current thread and <see cref="IScope"/>,
+    /// updating the <see cref="IScopeManager.Active"/> in the process.
+    /// NOTE: Calling <see cref="IScope.Dispose()"/> more than once on a single <see cref="IScope"/> instance leads to undefined
+    /// behavior.
+    /// </summary>
+    /// <seealso cref="System.IDisposable" />
+    public interface IScope : IDisposable
+    {
+        /// <summary>
+        /// Returns the <see cref="ISpan"/> that's been scoped by this<see cref="IScope"/>
+        /// </summary>
+        ISpan Span { get; }
+    }
+}

--- a/src/OpenTracing/IScopeManager.cs
+++ b/src/OpenTracing/IScopeManager.cs
@@ -1,0 +1,39 @@
+﻿
+namespace OpenTracing
+{
+    /// <summary>
+    /// The <see cref="IScopeManager"/> interface abstracts both the activation of <see cref="ISpan"/> instances (via
+    /// <see cref="Activate(ISpan, bool)"/> and access to an active <see cref="ISpan"/>/<see cref="IScope"/>
+    /// (via <see cref="Active"/>).
+    /// <see cref="IScope"/>
+    /// <see cref="ITracer.ScopeManager"/>
+    /// </summary>
+    public interface IScopeManager
+    {
+        /// <summary>
+        /// Make a <see cref="ISpan"/> instance active.
+        /// </summary>
+        /// <param name="span">The <see cref="ISpan"/> that should become the <see cref="Active"/>
+        /// <returns>A <see cref="IScope"/> instance to control the end of the active period for the <see cref="ISpan"/>. It is a
+        /// programming error to neglect to call <see cref="IScope.Dispose()"/> on the returned instance.</returns>
+        IScope Activate(ISpan span);
+
+        /// <summary>
+        /// Make a <see cref="ISpan"/> instance active.
+        /// </summary>
+        /// <param name="span">The <see cref="ISpan"/> that should become the <see cref="Active"/>
+        /// <param name="finishSpanOnClose">Whether span should automatically be finished when <see cref="IScope.Dispose()"/>is called</param>
+        /// <returns>A <see cref="IScope"/> instance to control the end of the active period for the <see cref="ISpan"/>. It is a
+        /// programming error to neglect to call <see cref="IScope.Dispose()"/> on the returned instance.</returns>
+        IScope Activate(ISpan span, bool finishSpanOnClose);
+
+        /// <summary>
+        /// Return the currently active <see cref="IScope"/> which can be used to access the currently active
+        /// <see cref="IScope.Span"/>, or null if none could be found.
+        /// If there is an non null <see cref="IScope"/>, its wrapped <see cref="ISpan"/> becomes an implicit parent of any
+        /// newly-created <see cref="ISpan"/> at <see cref="ISpanBuilder.StartActive()"/> time (rather than at
+        /// <see cref="ITracer.BuildSpan(string)"/> time).  
+        /// </summary>
+        IScope Active { get; }
+    }
+}

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -75,8 +75,72 @@ namespace OpenTracing
         ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp);
 
         /// <summary>
-        /// Returns the started span.
+        /// Do not create an implicit <see cref="References.ChildOf"/> reference to the <see cref="IScopeManager.Active"/>.
         /// </summary>
-        ISpan Start();
+        /// <returns></returns>
+        ISpanBuilder IgnoreActiveSpan();
+
+        /// <summary>
+        /// Returns a newly started and activated <see cref="IScope"/>.
+        /// For detailed information, see <see cref="StartActive(bool)"/>
+        /// <seealso cref="IScopeManager"/>
+        /// <seealso cref="IScope"/>
+        /// <seealso cref="StartActive(bool)"/>
+        /// </summary>
+        /// <returns>A <see cref="IScope"/> already registered via the <see cref="ITracer.ScopeManager"/></returns>
+        /// <example>
+        /// The returned <see cref="IScope"/> implements <see cref="IDisposable"/> and can be used within a using statement.
+        /// <code>
+        ///     using (IScope scope = tracer.BuildSpan("...").StartActive()) {
+        ///         // (Do work)
+        ///         scope.Span.SetTag( ... );  // etc, etc
+        ///     }
+        ///     // the <see cref="ISpan"/> finishes automatically when the <see cref="IScope"/> is disposed,
+        ///     // following the default behavior of <see cref="IScopeManager.Activate(ISpan, bool)"/>
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// <see cref="StartActive()"/> is a shorthand for
+        /// <c> tracer.scopeManager().activate(spanBuilder.startManual()) </c>
+        /// </remarks>
+        IScope StartActive();
+
+        /// <summary>
+        /// Returns a newly started and activated <see cref="IScope"/>.
+        /// If the <see cref="ITracer"/>'s <see cref="IScopeManager.Active"/> is not null, and
+        /// no explicit references are added via <see cref="AddReference(string, ISpanContext)"/>, and
+        /// <see cref="IgnoreActiveSpan()"/> is not invoked, then an inferred <see cref="References.ChildOf"/>
+        /// reference is created to the <see cref="IScopeManager.Active"/>'s <see cref="ISpanContext"/> when either
+        /// <see cref="StartManual"/> or <see cref="StartActive()"/> is invoked.
+        /// <seealso cref="IScopeManager"/>
+        /// <seealso cref="IScope"/>
+        /// </summary>
+        /// <param name="finishSpanOnClose">Whether the <see cref="ISpan"/> should automatically be finished when <see cref="IScope.Dispose()"/> is called </param>
+        /// <returns>A <see cref="IScope"/> already registered via the <see cref="ITracer.ScopeManager"/></returns>
+        /// <example>
+        /// The returned <see cref="IScope"/> implements <see cref="IDisposable"/> and can be used within a using statement.
+        /// <code>
+        ///     using (IScope scope = tracer.BuildSpan("...").StartActive(false)) {
+        ///         // (Do work)
+        ///         scope.Span.SetTag( ... );  // etc, etc
+        ///     }
+        ///     // The <see cref="ISpan"/> does not finish automatically when the <see cref="IScope"/> is disposed as
+        ///     // 'finishOnClose' is false
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// <see cref="StartActive(bool)"/> is a shorthand for
+        /// <c> tracer.scopeManager().activate(spanBuilder.startManual(), finishSpanOnClose) </c>
+        /// </remarks>
+        IScope StartActive(bool finishSpanOnClose);
+
+        /// <summary>
+        /// Like <see cref="StartActive()"/>, but the returned <see cref="ISpan"/> has not been registered via the
+        /// <see cref="IScopeManager"/>.
+        /// <seealso cref=StartActive()"/>
+        /// </summary>
+        /// <returns>The newly-started Span instance, which has *not* been automatically registered
+        /// via the <see cref="IScopeManager"/></returns>
+        ISpan StartManual();
     }
 }

--- a/src/OpenTracing/ITracer.cs
+++ b/src/OpenTracing/ITracer.cs
@@ -8,6 +8,11 @@ namespace OpenTracing
     public interface ITracer
     {
         /// <summary>
+        /// Returns the current <see cref="IScopeManager"/>, which may be a noop but may not be null.
+        /// </summary>
+        IScopeManager ScopeManager { get; }
+
+        /// <summary>
         /// Returns a new <see cref="ISpanBuilder" /> for a span with the given <paramref name="operationName" />.
         /// </summary>
         /// <param name="operationName">The operation name of the span.</param>

--- a/src/OpenTracing/NullTracer/NullScope.cs
+++ b/src/OpenTracing/NullTracer/NullScope.cs
@@ -1,0 +1,13 @@
+﻿namespace OpenTracing.NullTracer
+{
+    public class NullScope : IScope
+    {
+        public static NullScope Instance = new NullScope();
+
+        public ISpan Span => NullSpan.Instance;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/OpenTracing/NullTracer/NullScopeManager.cs
+++ b/src/OpenTracing/NullTracer/NullScopeManager.cs
@@ -1,0 +1,19 @@
+﻿namespace OpenTracing.NullTracer
+{
+    public class NullScopeManager : IScopeManager
+    {
+        public static NullScopeManager Instance = new NullScopeManager();
+
+        public IScope Active => null;
+
+        public IScope Activate(ISpan span)
+        {
+            return NullScope.Instance;
+        }
+
+        public IScope Activate(ISpan span, bool finishSpanOnClose)
+        {
+            return NullScope.Instance;
+        }
+    }
+}

--- a/src/OpenTracing/NullTracer/NullSpanBuilder.cs
+++ b/src/OpenTracing/NullTracer/NullSpanBuilder.cs
@@ -60,7 +60,22 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpan Start()
+        public ISpanBuilder IgnoreActiveSpan()
+        {
+            return this;
+        }
+
+        public IScope StartActive()
+        {
+            return NullScope.Instance;
+        }
+
+        public IScope StartActive(bool finishSpanOnClose)
+        {
+            return NullScope.Instance;
+        }
+
+        public ISpan StartManual()
         {
             return NullSpan.Instance;
         }

--- a/src/OpenTracing/NullTracer/NullTracer.cs
+++ b/src/OpenTracing/NullTracer/NullTracer.cs
@@ -6,6 +6,8 @@ namespace OpenTracing.NullTracer
     {
         public static readonly NullTracer Instance = new NullTracer();
 
+        public IScopeManager ScopeManager => NullScopeManager.Instance;
+
         private NullTracer()
         {
         }


### PR DESCRIPTION
This PR brings to opentracing-csharp the concepts of Scope and ScopeManager that were introduced in opentracing-java in: https://github.com/opentracing/opentracing-java/pull/182.

The motivation is:
- To allow for automatic and configurable context propagation.
- To bring the ability to retrieve the currently active span from the tracer.

There is already an ongoing PR covering the same topic but it seems like it has been on hold for a while: https://github.com/opentracing/opentracing-csharp/pull/36

The advantages that I see in pulling these abstractions from Java are:
- Keeping the two APIs as consistent as possible.
- Bring the same flexibility about starting Spans without making them active, ignoring the current active span for parent, closing or not a span when a scope is finished. (If some people need it in Java I don't see what makes it irrelevant for C#)
- Allow to plug different `IScopeManager` implementations. Indeed most of the time the AsyncLocal/CallContext implementation will be sufficient, however I think this abstraction could be useful to handle non async/await concurrency models. Looking for a potential use case, I've found out that the threading model used by some (ancient?) versions of ASP.NET with IIS could require using HttpContext instead of CallContext since it's not properly propagated  (see this [SO answer](https://stackoverflow.com/a/657748) and in particular this [blog post](http://piers7.blogspot.fr/2005/11/threadstatic-callcontext-and_02.html))

The purpose of this PR is not to trump the existing PR but to revive the debate by proposing another direction and hopefully bring context propagation and the ability to retrieve the current active span to opentracing-csharp in a near future.